### PR TITLE
Fix/py pkg missing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-pytest==7.4.2
+pytest==7.1.3
 pytest-selenium==4.0.1
 selenium==4.9.1
 flake8==6.0.0
-pytest-html==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest==7.4.2
 pytest-selenium==4.0.1
 selenium==4.9.1
 flake8==6.0.0
+pytest-html==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pytest==7.1.3
+pytest
+py
 pytest-selenium==4.0.1
 selenium==4.9.1
 flake8==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest==7.3.2
+pytest==7.4.2
 pytest-selenium==4.0.1
 selenium==4.9.1
 flake8==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pytest
-py
+pytest==7.4.2
 pytest-selenium==4.0.1
 selenium==4.9.1
 flake8==6.0.0
+py==1.11.0


### PR DESCRIPTION
Add py package to fix Testery failure.
Context:
```txt
This is caused by pre-installed packages assuming the py package is installed. Pytest does not install this package anymore after version 7.1.3. So there are two work arounds at the moment
Roll back your pytest version to 7.1.3 or
Explicitly add py to your requirements.txt file.
```